### PR TITLE
Return exit code from execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Type declarations have been added to class properties.
+- Exit value returned from implementation's `execute()` method is returned to
+  the console. A non-zero value will stop the process iteration.
 ### Changed
 - **BC break**: Reduce visibility of internal methods and properties. These
   members are not part of the public API. No impact to standard use of this

--- a/README.md
+++ b/README.md
@@ -57,8 +57,12 @@ class MyProcessCommand extends BackgroundCommand
 
 ### Stopping execution
 
+#### Normal usage
+
 Typically, the command will continue execution until interrupted by a signal,
 e.g. a user pressing `Ctrl+C`.
+
+#### Self-termination
 
 Alternatively, if an implementation has a finite task, for example deleting
 records in batches, it may need to terminate itself once the task is complete.
@@ -76,6 +80,31 @@ class MyProcessCommand extends BackgroundCommand
             $output->writeln('All done!');
             $this->shutdown();
         }
+        return 0;
+    }
+}
+```
+
+#### Non-zero exit
+
+If an execution returns a non-zero exit code, iteration will be stopped and the
+exit code will be passed back to the console, as with a normal Symfony Command.
+
+```php
+class MyProcessCommand extends BackgroundCommand
+{
+    // ...
+    
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $isInputValid = $this->someValidationChecks($input);
+        if ($isInputValid === false) {
+            $output->writeln('Message explaining invalid input');
+            return 1;
+        }
+        
+        // do some work
+        
         return 0;
     }
 }

--- a/src/Command/BackgroundCommand.php
+++ b/src/Command/BackgroundCommand.php
@@ -47,7 +47,7 @@ class BackgroundCommand extends Command
     /**
      * @internal This method is not part of the backward-compatibility promise.
      */
-    protected function background(InputInterface $input, OutputInterface $output): void
+    protected function background(InputInterface $input, OutputInterface $output): int
     {
         $this->registerSignals($output);
         if ($output->isVerbose()) {
@@ -70,6 +70,8 @@ class BackgroundCommand extends Command
             $output->writeln('Background process shutting down.');
         }
         $this->onShutdown($input, $output);
+
+        return 0;
     }
 
     /**

--- a/src/Command/BackgroundCommand.php
+++ b/src/Command/BackgroundCommand.php
@@ -54,9 +54,14 @@ class BackgroundCommand extends Command
             $output->writeln('Background PCNTL Signals registered.');
         }
 
+        $exitCode = 0;
         while ($this->continue) {
             try {
-                call_user_func($this->backgroundExecute, $input, $output);
+                $exitCode = call_user_func($this->backgroundExecute, $input, $output);
+                if ($exitCode > 0) {
+                    $this->shutdown();
+                    break;
+                }
                 pcntl_signal_dispatch();
                 $this->sleep();
             } catch (\Exception $e) {
@@ -71,7 +76,7 @@ class BackgroundCommand extends Command
         }
         $this->onShutdown($input, $output);
 
-        return 0;
+        return $exitCode;
     }
 
     /**

--- a/src/Command/DaemonCommand.php
+++ b/src/Command/DaemonCommand.php
@@ -91,16 +91,11 @@ class DaemonCommand extends BackgroundCommand
         try {
             $output->writeln('Daemon executing main process.');
             parent::background($input, $output);
-        } catch (\Exception $e) {
+        } finally {
+            $output->writeln('Daemon process shutting down.');
             if ($pidFile !== null && file_exists($pidFile)) {
                 unlink($pidFile);
             }
-            throw $e;
-        }
-
-        $output->writeln('Daemon process shutting down.');
-        if ($pidFile !== null && file_exists($pidFile)) {
-            unlink($pidFile);
         }
     }
 

--- a/src/Command/DaemonCommand.php
+++ b/src/Command/DaemonCommand.php
@@ -41,17 +41,24 @@ class DaemonCommand extends BackgroundCommand
     {
     }
 
-    final protected function background(InputInterface $input, OutputInterface $output): void
+    final protected function background(InputInterface $input, OutputInterface $output): int
     {
         $action = strtolower($input->getArgument('action'));
-        if (!in_array($action, ['start', 'stop', 'status'], true)) {
-            throw new \InvalidArgumentException("Provided action is invalid, expecting 'start', 'stop' or 'status'.");
+        switch ($action) {
+            case 'start':
+                return $this->start($input, $output);
+            case 'stop':
+                return $this->stop($input, $output);
+            case 'status':
+                return $this->status($input, $output);
+            default:
+                throw new \InvalidArgumentException(
+                    "Provided action is invalid, expecting 'start', 'stop' or 'status'."
+                );
         }
-
-        $this->{$action}($input, $output);
     }
 
-    private function start(InputInterface $input, OutputInterface $output): void
+    private function start(InputInterface $input, OutputInterface $output): int
     {
         $pidFile = null;
         if ($input->getOption('daemonize')) {
@@ -71,7 +78,7 @@ class DaemonCommand extends BackgroundCommand
                     $output->writeln('Parent process completing.');
                 }
                 $this->onAfterDaemonizeParent($input, $output);
-                return;
+                return 0;
             }
 
             // children shouldn't hold onto parents input/output
@@ -90,7 +97,7 @@ class DaemonCommand extends BackgroundCommand
 
         try {
             $output->writeln('Daemon executing main process.');
-            parent::background($input, $output);
+            return parent::background($input, $output);
         } finally {
             $output->writeln('Daemon process shutting down.');
             if ($pidFile !== null && file_exists($pidFile)) {
@@ -125,7 +132,7 @@ class DaemonCommand extends BackgroundCommand
         return true;
     }
 
-    private function stop(InputInterface $input, OutputInterface $output): void
+    private function stop(InputInterface $input, OutputInterface $output): int
     {
         $pidFile = $this->getPidFilename($input);
 
@@ -144,14 +151,16 @@ class DaemonCommand extends BackgroundCommand
                 usleep(500000);
             } while (posix_kill($pid, 0));
         }
+
+        return 0;
     }
 
-    private function status(InputInterface $input, OutputInterface $output): void
+    private function status(InputInterface $input, OutputInterface $output): int
     {
         $pidFile = $this->getPidFilename($input);
         if (!file_exists($pidFile)) {
             $output->writeln('Not running');
-            return;
+            return 0;
         }
 
         $fileHandle = @fopen($pidFile, 'r');
@@ -168,6 +177,8 @@ class DaemonCommand extends BackgroundCommand
         } else {
             $output->writeln('Not running');
         }
+
+        return 0;
     }
 
     private function recreateInput(InputInterface $input): InputInterface

--- a/tests/Command/BackgroundCommandTest.php
+++ b/tests/Command/BackgroundCommandTest.php
@@ -22,6 +22,14 @@ class BackgroundCommandTest extends TestCase
 
     protected CommandTester $tester;
 
+    public static function setUpBeforeClass(): void
+    {
+        static::defineFunctionMock(__NAMESPACE__, 'pcntl_signal_dispatch');
+        static::defineFunctionMock(__NAMESPACE__, 'usleep');
+
+        parent::setUpBeforeClass();
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -50,5 +58,42 @@ class BackgroundCommandTest extends TestCase
             ->withConsecutive([SIGTERM], [SIGINT]);
 
         $this->tester->execute([]);
+    }
+
+    public function testShutdownOnNextIteration(): void
+    {
+        // Signal dispatch will be called
+        $dispatch = $this->getFunctionMock(__NAMESPACE__, 'pcntl_signal_dispatch');
+        $dispatch->expects(static::once())
+            ->willReturn(true);
+
+        // Sleep between executions
+        $sleep = $this->getFunctionMock(__NAMESPACE__, 'usleep');
+        $sleep->expects(static::once())
+            ->willReturn(true);
+
+        $this->tester->execute([]);
+
+        static::assertSame(1, $this->command->getExecuteCount());
+    }
+
+    public function testExitCodeShutdown(): void
+    {
+        $exitCode = rand(1, 50);
+
+        $this->command->setExitCode($exitCode);
+
+        // Exit before processing signals
+        $dispatch = $this->getFunctionMock(__NAMESPACE__, 'pcntl_signal_dispatch');
+        $dispatch->expects(static::never());
+
+        // Exit before calling sleep
+        $sleep = $this->getFunctionMock(__NAMESPACE__, 'sleep');
+        $sleep->expects(static::never());
+
+        $actual = $this->tester->execute([]);
+
+        static::assertSame($exitCode, $actual);
+        static::assertSame(1, $this->command->getExecuteCount());
     }
 }

--- a/tests/Command/Stub/ExecuteStubTrait.php
+++ b/tests/Command/Stub/ExecuteStubTrait.php
@@ -9,21 +9,49 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait ExecuteStubTrait
 {
+    private int $executeCount = 0;
+
     private string $executeValue;
+
+    private bool $shutdown = true;
+
+    private int $exitCode = 0;
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $this->executeCount++;
+
         if (isset($this->executeValue)) {
             $output->writeln($this->executeValue);
         }
-        $this->shutdown();
 
-        return 0;
+        if ($this->shutdown) {
+            $this->shutdown();
+        }
+
+        return $this->exitCode;
     }
 
     public function setExecuteOutput(string $value): self
     {
         $this->executeValue = $value;
         return $this;
+    }
+
+    public function setShutdown(bool $shutdown): self
+    {
+        $this->shutdown = $shutdown;
+        return $this;
+    }
+
+    public function setExitCode(int $exitCode): self
+    {
+        $this->exitCode = $exitCode;
+        return $this;
+    }
+
+    public function getExecuteCount(): int
+    {
+        return $this->executeCount;
     }
 }


### PR DESCRIPTION
- Add int return type to `background()`.
- Pass exit code to console, allowing non-zero return to stop iteration.