### PR TITLE
Add child log option to DaemonCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Type declarations have been added to class properties.
 - Exit value returned from implementation's `execute()` method is returned to
   the console. A non-zero value will stop the process iteration.
+- Native input option for `DaemonCommand` to set the child log output filename.
+  This should remove a common need to override `DaemonCommand::createChildOutput()`.
 ### Changed
 - **BC break**: Reduce visibility of internal methods and properties. These
   members are not part of the public API. No impact to standard use of this
   package. If an implementation has a use case which needs to override these
   members, please submit a pull request explaining the change.
+- **BC break**: New parameter added for `DaemonCommand::createChildOutput()`,
+  which will be a BC break for implementations that override that method.
 ### Removed
 - **BC break**: Removed support for PHP v7.3 as it is no longer
   [actively supported](https://php.net/supported-versions.php) by the PHP project.

--- a/README.md
+++ b/README.md
@@ -164,9 +164,10 @@ class MyProcessCommand extends DaemonCommand
 
 ### Output
 
-Once a daemon process is detached, the original output is also lost. The daemon command class provides a 
-protected method to specify a new output. If this method isn't overriden, then by default, the output is a
-```NullOutput``` Symfony object. The following example demonstrates overriding the method.
+Once a daemon process is detached, the original output is also lost.
+The `--child-log | -o` option can be used to specify a filename to write output.
+Alternatively, the `createChildOutput()` method can be overridden to return a
+new output instance. For example:
 
 ```php
 use Symfony\Component\Console\Output\StreamOutput;
@@ -177,7 +178,7 @@ class MyProcessCommand extends DaemonCommand
     
     protected function createChildOutput()
     {
-        return new StreamOutput(fopen(getcwd() . '/my-daemon.log', 'a'));
+        return new MyOutputToLoggerClass();
     }
 }
 ```
@@ -230,6 +231,7 @@ class MyProcessCommand extends DaemonCommand
 |action| |Argument|yes| |start, stop, status|
 |daemonize|d|Option|no|no|Detaches the process|
 |pid-file|p|Option|no|auto|Name of the PID file to use. Not used if daemonize is not set.|
+|child-log|o|Option|no|no|Name of the file to save child output. Not used if daemonize is not set.|
 
 ## License
 

--- a/example/Daemon.php
+++ b/example/Daemon.php
@@ -42,9 +42,4 @@ class Daemon extends DaemonCommand
     {
         $output->writeln('onShutdown method called.');
     }
-
-    protected function createChildOutput(): OutputInterface
-    {
-        return new StreamOutput(fopen(getcwd() . '/daemon.log', 'a'));
-    }
 }

--- a/src/Command/DaemonCommand.php
+++ b/src/Command/DaemonCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * Class DaemonCommand
@@ -26,7 +27,13 @@ class DaemonCommand extends BackgroundCommand
     {
         $this->addArgument('action', InputArgument::REQUIRED, 'Start, stop or status.')
             ->addOption('pid-file', 'p', InputOption::VALUE_REQUIRED, 'PID file location.', false)
-            ->addOption('daemonize', 'd', InputOption::VALUE_NONE, 'Make the process run in the background and detach.');
+            ->addOption('daemonize', 'd', InputOption::VALUE_NONE, 'Make the process run in the background and detach.')
+            ->addOption(
+                'child-log',
+                'o',
+                InputOption::VALUE_REQUIRED,
+                'File location to log child output, when using <info>--daemonize</info>',
+            );
     }
 
     protected function onBeforeDaemonize(InputInterface $input, OutputInterface $output): void
@@ -82,8 +89,9 @@ class DaemonCommand extends BackgroundCommand
             }
 
             // children shouldn't hold onto parents input/output
+            $childLogFilename = $input->getOption('child-log');
             $input = $this->recreateInput($input);
-            $output = $this->recreateOutput($output);
+            $output = $this->recreateOutput($output, $childLogFilename);
 
             $output->writeln('Child process forked.');
             $this->onAfterDaemonizeChild($input, $output);
@@ -186,17 +194,32 @@ class DaemonCommand extends BackgroundCommand
         return clone $input;
     }
 
-    private function recreateOutput(OutputInterface $output): OutputInterface
+    private function recreateOutput(OutputInterface $output, ?string $childLogFilename): OutputInterface
     {
         $verbosityLevel = $output->getVerbosity();
-        $newInstance = $this->createChildOutput();
+        $newInstance = $this->createChildOutput($childLogFilename);
         $newInstance->setVerbosity($verbosityLevel);
         return $newInstance;
     }
 
-    protected function createChildOutput(): OutputInterface
+    protected function createChildOutput(?string $childLogFilename): OutputInterface
     {
-        return new NullOutput();
+        if (empty($childLogFilename)) {
+            return new NullOutput();
+        }
+
+        if (file_exists($childLogFilename)) {
+            if (!is_file($childLogFilename)) {
+                throw new \InvalidArgumentException(sprintf("Child log file '%s' is not a file.", $childLogFilename));
+            }
+            if (!is_writable($childLogFilename)) {
+                throw new \InvalidArgumentException(sprintf("Child log file '%s' is not writable.", $childLogFilename));
+            }
+        } elseif (!is_writable(dirname($childLogFilename))) {
+            throw new \InvalidArgumentException(sprintf("Cannot create child log file '%s'.", $childLogFilename));
+        }
+
+        return new StreamOutput(fopen($childLogFilename, 'a'));
     }
 
     private function getPidFilename(InputInterface $input): string

--- a/tests/Command/DaemonCommandTest.php
+++ b/tests/Command/DaemonCommandTest.php
@@ -148,13 +148,8 @@ class DaemonCommandTest extends TestCase
         ]);
     }
 
-    protected function setupStartFunctions(
-        ?int $fork,
-        int $setsid = 0,
-        bool $fexists = false,
-        bool $writeable = true,
-        bool $putContents = true
-    ): void {
+    private function setupStartFunctions(?int $fork, int $setsid = 0): void
+    {
         $pcntl_fork = $this->getFunctionMock(__NAMESPACE__, 'pcntl_fork');
         $pcntl_fork->expects(static::any())->willReturn($fork);
 
@@ -162,13 +157,13 @@ class DaemonCommandTest extends TestCase
         $posix_setsid->expects(static::any())->willReturn($setsid);
 
         $file_exists = $this->getFunctionMock(__NAMESPACE__, 'file_exists');
-        $file_exists->expects(static::any())->willReturn($fexists);
+        $file_exists->expects(static::any())->willReturn(false);
 
         $is_writable = $this->getFunctionMock(__NAMESPACE__, 'is_writable');
-        $is_writable->expects(static::any())->willReturn($writeable);
+        $is_writable->expects(static::any())->willReturn(true);
 
         $is_writable = $this->getFunctionMock(__NAMESPACE__, 'file_put_contents');
-        $is_writable->expects(static::any())->willReturn($putContents);
+        $is_writable->expects(static::any())->willReturn(true);
 
         $is_writable = $this->getFunctionMock(__NAMESPACE__, 'unlink');
         $is_writable->expects(static::any())->willReturn(true);
@@ -177,28 +172,19 @@ class DaemonCommandTest extends TestCase
         $usleep->expects(static::any())->willReturn(true);
     }
 
-    protected function setupStopFunctions(
-        int $pid,
-        bool $fexists = true,
-        bool $opened = true,
-        bool $withPosixKill = false
-    ): void {
+    private function setupStopFunctions(int $pid): void
+    {
         $file_exists = $this->getFunctionMock(__NAMESPACE__, 'file_exists');
-        $file_exists->expects(static::any())->willReturn($fexists);
+        $file_exists->expects(static::any())->willReturn(true);
 
         $fopen = $this->getFunctionMock(__NAMESPACE__, 'fopen');
-        $fopen->expects(static::any())->willReturn($opened);
+        $fopen->expects(static::any())->willReturn(true);
 
         $fgets = $this->getFunctionMock(__NAMESPACE__, 'fgets');
         $fgets->expects(static::any())->willReturn($pid);
 
         $fclose = $this->getFunctionMock(__NAMESPACE__, 'fclose');
         $fclose->expects(static::any())->willReturn(true);
-
-        if ($withPosixKill) {
-            $posix_kill = $this->getFunctionMock(__NAMESPACE__, 'posix_kill');
-            $posix_kill->expects(static::any())->willReturn(false);
-        }
 
         $usleep = $this->getFunctionMock(__NAMESPACE__, 'usleep');
         $usleep->expects(static::any())->willReturn(true);

--- a/tests/Command/Stub/DaemonCommandStub.php
+++ b/tests/Command/Stub/DaemonCommandStub.php
@@ -29,9 +29,13 @@ class DaemonCommandStub extends DaemonCommand
         return $this;
     }
 
-    protected function createChildOutput(): OutputInterface
+    protected function createChildOutput(?string $childLogFilename): OutputInterface
     {
-        return call_user_func($this->outputCallback);
+        if (isset($this->outputCallback)) {
+            return ($this->outputCallback)();
+        }
+
+        return parent::createChildOutput($childLogFilename);
     }
 
     public function setOutputCallback(\Closure $callback): self


### PR DESCRIPTION
- Build in common use-case for writing output to local file.
- Major version because any implementations overriding `createChildOutput()` will have a BC-break as the method signature has changed.