### PR TITLE
On start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- New `onStart()` method that can be overridden to include code to only run
+  once, before `execute()`.
 
 ## [3.0.0] - 2021-10-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ class MyProcessCommand extends BackgroundCommand
 ### Lifecycle Methods
 
 The background command has additional methods that get called when the process
-finishes, which can be used for any final cleanup.
+starts and finishes. Useful for any initialising or final cleanup.
 
+  * `onStart(InputInterface $input, OutputInterface $output): void`
+    * Similar to standard `initialize()`; useful for `DaemonCommand`.
   * `onShutdown(InputInterface $input, OutputInterface $output): void`
   * `onException(\Exception $e, InputInterface $input, OutputInterface $output): void`
 
@@ -206,6 +208,12 @@ class MyProcessCommand extends DaemonCommand
     protected function onAfterDaemonizeParent(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('onAfterDaemonizeParent method called.');
+    }
+    
+    protected function onStart(InputInterface $input, OutputInterface $output): void
+    {
+        // Similar to `onAfterDaemonizeChild()` but also called if `--daemonize` option is not set.
+        $output->writeln('onStart method called.');
     }
 }
 ```

--- a/src/Command/BackgroundCommand.php
+++ b/src/Command/BackgroundCommand.php
@@ -93,6 +93,10 @@ class BackgroundCommand extends Command
     {
     }
 
+    /**
+     * @todo v4: Update $e parameter type to \Throwable
+     * @param \Throwable $e
+     */
     protected function onException(\Exception $e, InputInterface $input, OutputInterface $output): void
     {
     }

--- a/src/Command/BackgroundCommand.php
+++ b/src/Command/BackgroundCommand.php
@@ -51,6 +51,7 @@ class BackgroundCommand extends Command
     {
         $this->registerSignals($output);
         $output->writeln('Background PCNTL Signals registered.', OutputInterface::VERBOSITY_VERBOSE);
+        $this->onStart($input, $output);
 
         $exitCode = 0;
         while ($this->continue) {
@@ -82,6 +83,10 @@ class BackgroundCommand extends Command
     final protected function shutdown(): void
     {
         $this->continue = false;
+    }
+
+    protected function onStart(InputInterface $input, OutputInterface $output): void
+    {
     }
 
     protected function onShutdown(InputInterface $input, OutputInterface $output): void

--- a/tests/Command/BackgroundCommandTest.php
+++ b/tests/Command/BackgroundCommandTest.php
@@ -80,6 +80,9 @@ class BackgroundCommandTest extends TestCase
         $this->tester->execute([]);
 
         static::assertSame(1, $this->command->getExecuteCount());
+        static::assertTrue($this->command->onStartCalled);
+        static::assertTrue($this->command->onShutdownCalled);
+        static::assertFalse($this->command->onExceptionCalled);
     }
 
     public function testExitCodeShutdown(): void
@@ -100,5 +103,8 @@ class BackgroundCommandTest extends TestCase
 
         static::assertSame($exitCode, $actual);
         static::assertSame(1, $this->command->getExecuteCount());
+        static::assertTrue($this->command->onStartCalled);
+        static::assertTrue($this->command->onShutdownCalled);
+        static::assertFalse($this->command->onExceptionCalled);
     }
 }

--- a/tests/Command/Stub/BackgroundCommandStub.php
+++ b/tests/Command/Stub/BackgroundCommandStub.php
@@ -5,8 +5,34 @@ declare(strict_types=1);
 namespace Phlib\ConsoleProcess\Command\Stub;
 
 use Phlib\ConsoleProcess\Command\BackgroundCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class BackgroundCommandStub extends BackgroundCommand
 {
     use ExecuteStubTrait;
+
+    public bool $onStartCalled = false;
+
+    public bool $onShutdownCalled = false;
+
+    public bool $onExceptionCalled = false;
+
+    public \Exception $onExceptionCalledWith;
+
+    protected function onStart(InputInterface $input, OutputInterface $output): void
+    {
+        $this->onStartCalled = true;
+    }
+
+    protected function onShutdown(InputInterface $input, OutputInterface $output): void
+    {
+        $this->onShutdownCalled = true;
+    }
+
+    protected function onException(\Exception $e, InputInterface $input, OutputInterface $output): void
+    {
+        $this->onExceptionCalled = true;
+        $this->onExceptionCalledWith = $e;
+    }
 }

--- a/tests/Command/Stub/ExecuteStubTrait.php
+++ b/tests/Command/Stub/ExecuteStubTrait.php
@@ -17,12 +17,18 @@ trait ExecuteStubTrait
 
     private int $exitCode = 0;
 
+    private \Throwable $exception;
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->executeCount++;
 
         if (isset($this->executeValue)) {
             $output->writeln($this->executeValue);
+        }
+
+        if (isset($this->exception)) {
+            throw $this->exception;
         }
 
         if ($this->shutdown) {
@@ -47,6 +53,12 @@ trait ExecuteStubTrait
     public function setExitCode(int $exitCode): self
     {
         $this->exitCode = $exitCode;
+        return $this;
+    }
+
+    public function setException(\Throwable $e): self
+    {
+        $this->exception = $e;
         return $this;
     }
 


### PR DESCRIPTION
- Add onStart() method that is called before execute(). Useful for `DaemonCommand` as it is only called after the child is forked.