### PR TITLE
fix: symfony/console:7.3 setCode call and php8.4 deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [5.0.0] - 2025-06-19
-### Changed
-- fix for symfony/console setCode() call
-- fix for PHP 8.4 deprecation warnings
-
 ## [4.0.1] - 2025-01-21
 ### Changed
 - Allow Symfony v7 dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.0.0] - 2025-06-19
+### Changed
+- fix for symfony/console setCode() call
+- fix for PHP 8.4 deprecation warnings
+
 ## [4.0.1] - 2025-01-21
 ### Changed
 - Allow Symfony v7 dependencies

--- a/src/Command/BackgroundCommand.php
+++ b/src/Command/BackgroundCommand.php
@@ -27,8 +27,7 @@ class BackgroundCommand extends Command
     public function __construct(?string $name = null)
     {
         parent::__construct($name);
-
-        parent::setCode(fn($input, $output) => $this->background($input, $output));
+        parent::setCode(\Closure::fromCallable([$this, 'background']));
 
         $this->backgroundExecute = [$this, 'execute'];
 

--- a/src/Command/BackgroundCommand.php
+++ b/src/Command/BackgroundCommand.php
@@ -24,11 +24,12 @@ class BackgroundCommand extends Command
      */
     private $backgroundExecute;
 
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         parent::__construct($name);
 
-        parent::setCode([$this, 'background']);
+        parent::setCode(fn ($input, $output) => $this->background($input, $output));
+
         $this->backgroundExecute = [$this, 'execute'];
 
         // add stop signals

--- a/src/Command/BackgroundCommand.php
+++ b/src/Command/BackgroundCommand.php
@@ -28,7 +28,7 @@ class BackgroundCommand extends Command
     {
         parent::__construct($name);
 
-        parent::setCode(fn ($input, $output) => $this->background($input, $output));
+        parent::setCode(fn($input, $output) => $this->background($input, $output));
 
         $this->backgroundExecute = [$this, 'execute'];
 

--- a/src/Command/DaemonCommand.php
+++ b/src/Command/DaemonCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class DaemonCommand extends BackgroundCommand
 {
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         parent::__construct($name);
         $this->configureDaemon();


### PR DESCRIPTION
* the usage of  `parent::setCode()` in Symfony 7.3 has changed, it requires now a callable
* fixed PHP 8.4 deprecation warning (see #19)